### PR TITLE
Run headless, use SSL, and fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,16 @@
+wheel>=0.33.6
+
+-e git+https://github.com/cobrateam/splinter.git@0.11.0#egg=splinter
+
 args==0.1.0
 beautifulsoup4==4.6.3
 bs4==0.0.1
 clint==0.5.1
 docopt==0.6.2
-pkg-resources==0.0.0
 python-dateutil==2.5.3
-pyyaml>=4.2b1
-requests>=2.20.0
+PyYAML==5.1.2
 schema==0.5.0
-selenium==3.14.1
-six==1.11.0
-splinter==0.7.3
+selenium==3.141.0
+six==1.12.0
 urljoin==1.0.0
-urllib3>=1.24.2
-wheel>=0.33.6
-
+urllib[secure]==1.25.6


### PR DESCRIPTION
I needed to back up a couple of Yahoo groups and I stumbled upon this project, but I hit some snags trying to use it. For one thing, it bothered me it actually relied on opening a browser's GUI. Updating splinter to the latest build (which is what that new git requirement is) allowed for that.

Then it was throwing a bunch of SSL errors. I could've just suppressed them, but I figured if it was worth doing, it was worth doing right, so I swapped out the requests library for urllib3[secure], which uses pyOpenSSL.

Other minor adjustments include moving the 'Detecting' messages to a place where they wouldn't get spammed, a `Loader` argument to the yaml loader to shut that warning up, and an if statement to skip attaching a mobile phone number to the yahoo account.

Lastly I put the oath page processing in a try-catch because it just never found an Agree button and exploded. I'm not sure what the oath page even looks like so I couldn't do anything more than that.

Hopefully I didn't forget anything.